### PR TITLE
Apply consistency when no forward solutions found

### DIFF
--- a/hklpy2/backends/hkl_soleil.py
+++ b/hklpy2/backends/hkl_soleil.py
@@ -43,7 +43,7 @@ import platform
 from pyRestTable import Table
 
 from ..misc import IDENTITY_MATRIX_3X3
-from ..misc import SolverNoForwardSolutions
+from ..misc import NoForwardSolutions
 from ..misc import check_value_in_list
 from ..misc import istype
 from ..misc import roundoff
@@ -349,8 +349,7 @@ class HklSolver(SolverBase):
                 LIBHKL_USER_UNITS,
             )
         except GLib.GError as exc:
-            msg = "No forward solutions found."
-            raise SolverNoForwardSolutions(msg) from exc
+            raise NoForwardSolutions("No forward solutions found.") from exc
 
         solutions = []
         for glist_item in raw_solutions.items():

--- a/hklpy2/misc.py
+++ b/hklpy2/misc.py
@@ -53,16 +53,16 @@ Miscellaneous Support.
 .. rubric: Custom Exceptions
 .. autosummary::
 
-    ~Hklpy2Error
     ~ConfigurationError
     ~ConstraintsError
-    ~DiffractometerError
-    ~LatticeError
     ~CoreError
+    ~DiffractometerError
+    ~Hklpy2Error
+    ~LatticeError
+    ~NoForwardSolutions
     ~ReflectionError
     ~SampleError
     ~SolverError
-    ~SolverNoForwardSolutions
 """
 
 import logging
@@ -156,6 +156,10 @@ class CoreError(Hklpy2Error):
     """Custom exceptions from :class:`~Core`."""
 
 
+class NoForwardSolutions(Hklpy2Error):
+    """A solver did not find any 'forward()' solutions."""
+
+
 class ReflectionError(Hklpy2Error):
     """Custom exceptions from :mod:`hklpy2.blocks.reflection`."""
 
@@ -166,10 +170,6 @@ class SampleError(Hklpy2Error):
 
 class SolverError(Hklpy2Error):
     """Custom exceptions from a |solver|."""
-
-
-class SolverNoForwardSolutions(SolverError):
-    """A solver did not find any 'forward()' solutions."""
 
 
 # Virtual positioner base class
@@ -866,7 +866,7 @@ def pick_closest_solution(
         :func:`~hklpy2.misc.pick_first_solution`
     """
     if len(solutions) == 0:
-        raise DiffractometerError("No solutions.")
+        raise NoForwardSolutions("No solutions.")
 
     nearest = None
     separation = None
@@ -901,7 +901,7 @@ def pick_first_solution(
         :func:`~hklpy2.misc.pick_closest_solution`
     """
     if len(solutions) == 0:
-        raise DiffractometerError("No solutions.")
+        raise NoForwardSolutions("No solutions.")
     return solutions[0]
 
 

--- a/hklpy2/ops.py
+++ b/hklpy2/ops.py
@@ -26,6 +26,7 @@ from .incident import DEFAULT_WAVELENGTH_UNITS
 from .misc import AnyAxesType
 from .misc import AxesDict
 from .misc import CoreError
+from .misc import NoForwardSolutions
 from .misc import axes_to_dict
 from .misc import convert_units
 from .misc import solver_factory
@@ -437,12 +438,14 @@ class Core:
         self.update_solver(wavelength=wavelength)
 
         # Filter just the solutions that fit the constraints.
-        results = self.solver.forward(self._axes_names_d2s(pdict))
         solutions = []
-        for solution in results:
-            reals.update(self._axes_names_s2d(solution))  # Update with new values.
-            if self.constraints.valid(**reals):
-                solutions.append(self.diffractometer.RealPosition(**reals))
+        try:
+            for solution in self.solver.forward(self._axes_names_d2s(pdict)):
+                reals.update(self._axes_names_s2d(solution))  # Update with new values.
+                if self.constraints.valid(**reals):
+                    solutions.append(self.diffractometer.RealPosition(**reals))
+        except NoForwardSolutions:
+            pass
 
         return solutions
 

--- a/hklpy2/tests/test_diffract.py
+++ b/hklpy2/tests/test_diffract.py
@@ -22,7 +22,7 @@ from ..diffract import creator
 from ..diffract import diffractometer_class_factory
 from ..misc import ConfigurationError
 from ..misc import DiffractometerError
-from ..misc import SolverNoForwardSolutions
+from ..misc import NoForwardSolutions
 from ..misc import VirtualPositionerBase
 from ..ops import DEFAULT_SAMPLE_NAME
 from ..ops import Core
@@ -154,8 +154,8 @@ def test_DiffractometerBase():
         [1, does_not_raise(), None],
         [-1.2, does_not_raise(), None],
         [1.2, does_not_raise(), None],
-        [12, pytest.raises(SolverNoForwardSolutions), "No forward solutions found."],
-        [-12, pytest.raises(SolverNoForwardSolutions), "No forward solutions found."],
+        [12, pytest.raises(NoForwardSolutions), "No solutions."],
+        [-12, pytest.raises(NoForwardSolutions), "No solutions."],
     ],
 )
 def test_limits(axis, value, context, expected):
@@ -657,8 +657,8 @@ def test_repeated_reflections(
                 fail_on_exception=True,
             ),
             "psi_constant",
-            pytest.raises(SolverNoForwardSolutions),
-            "No forward solutions found.",
+            pytest.raises(NoForwardSolutions),
+            "No solutions.",
         ],
         [
             dict(
@@ -787,7 +787,7 @@ def test_scan_extra_print_fail(scan_kwargs, mode, context, expected, capsys):
 
     out, err = capsys.readouterr()
     assert len(err) == 0
-    assert "FAIL: psi=555.0 No forward solutions found." in out
+    assert "FAIL: psi=555.0 No solutions." in out
 
 
 def test_set_UB():

--- a/hklpy2/tests/test_misc.py
+++ b/hklpy2/tests/test_misc.py
@@ -29,7 +29,7 @@ from ..misc import AxesDict
 from ..misc import AxesList
 from ..misc import AxesTuple
 from ..misc import ConfigurationRunWrapper
-from ..misc import DiffractometerError
+from ..misc import NoForwardSolutions
 from ..misc import SolverError
 from ..misc import VirtualPositionerBase
 from ..misc import axes_to_dict
@@ -562,7 +562,7 @@ def test_distance_between_pos_tuples(pos1, pos2, dist, tol, context, expected):
             (),
             pick_first_solution,
             None,
-            pytest.raises(DiffractometerError),
+            pytest.raises(NoForwardSolutions),
             "No solutions.",
         ],
         [
@@ -582,7 +582,7 @@ def test_distance_between_pos_tuples(pos1, pos2, dist, tol, context, expected):
             [],
             pick_closest_solution,
             None,
-            pytest.raises(DiffractometerError),
+            pytest.raises(NoForwardSolutions),
             "No solutions.",
         ],
     ],

--- a/hklpy2/tests/test_user.py
+++ b/hklpy2/tests/test_user.py
@@ -435,21 +435,42 @@ def test_solver_summary(fourc, capsys):
 
 
 @pytest.mark.parametrize(
-    "pseudos, text, context, expected",
+    "specs, mode, pseudos, text, context, expected",
     [
-        [(1, 0, 0), "RealPos(", does_not_raise(), None],
+        [{}, None, (1, 0, 0), "RealPos(", does_not_raise(), None],
         [
+            {},
+            None,
             (1, 0, 11_110),  # A reflection far beyond the Ewald sphere.
-            "No forward solutions found.",
+            "No solutions.",
+            does_not_raise(),
+            None,
+        ],
+        [
+            dict(geometry="APS POLAR"),
+            None,
+            (1, 0, 0),
+            "RealPos(",
+            does_not_raise(),
+            None,
+        ],
+        [
+            dict(geometry="APS POLAR"),
+            "psi constant vertical",
+            (1, 0, 0),
+            "No solutions.",
             does_not_raise(),
             None,
         ],
     ],
 )
-def test_cahkl_no_solutions(pseudos, text, context, expected):
+def test_cahkl_no_solutions(specs, mode, pseudos, text, context, expected):
     with context as reason:
-        sim = creator()
+        sim = creator(**specs)
+        if mode is not None:
+            sim.core.mode = mode
         set_diffractometer(sim)
-        assert text in str(cahkl(*pseudos))
+        result = cahkl(*pseudos)
+        assert text in str(result), f"{text=!r}  {str(result)=}"
 
     assert_context_result(expected, reason)

--- a/hklpy2/user.py
+++ b/hklpy2/user.py
@@ -35,7 +35,7 @@ from .diffract import DiffractometerBase
 from .misc import AnyAxesType
 from .misc import AxesDict
 from .misc import AxesTuple
-from .misc import SolverNoForwardSolutions
+from .misc import NoForwardSolutions
 from .ops import CoreError
 
 __all__ = """
@@ -147,7 +147,7 @@ def add_sample(
     return diffractometer.sample
 
 
-def cahkl(h: float, k: float, l: float):  # noqa: E741
+def cahkl(h: float, k: float, l: float) -> list | str:  # noqa: E741
     """
     Calculate motor positions for specified 'h, k l' - DOES NOT MOVE motors.
 
@@ -166,13 +166,12 @@ def cahkl(h: float, k: float, l: float):  # noqa: E741
     """
     diffractometer = get_diffractometer()
     try:
-        solutions = diffractometer.core.forward(pseudos=(h, k, l))
-    except SolverNoForwardSolutions as exinfo:
+        return diffractometer._forward_solution(
+            diffractometer.real_position,
+            diffractometer.core.forward(pseudos=(h, k, l)),
+        )
+    except NoForwardSolutions as exinfo:
         return str(exinfo)
-    return diffractometer._forward_solution(
-        diffractometer.real_position,
-        solutions,
-    )
 
 
 def cahkl_table(*reflections: list[AxesTuple], digits=4):


### PR DESCRIPTION
- closes #115

As [stated](https://github.com/bluesky/hklpy2/issues/115#issuecomment-3090620798):
- `cahkl()` should return text if no solutions
- `diffractometer.forward()` should raise `NoForwardSolutions`
- `diffractometer.core.forward()` should return an empty list