### PR TITLE
creator() now support custom motor specifications

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -33,7 +33,48 @@ describe future plans.
     0.2.0
     #####
 
-    Release expected 2025-Q3.
+    Release expected 2025-H2.
+
+0.1.6
+#####
+
+Released TBA.
+
+New Features
+-----------
+
+* '@crw_decorator()':  Decorator for the ConfigurationRunWrapper
+
+Fixes
+-----------
+
+* Allow update of '.core.extras["h2"] = 1.0'
+* Energy was not changed initially by 'wavelength.put(new_value)'.
+* DiffractometerError raised by 'hklpy2.user.wh()''
+* TypeError from 'diffractometer.wh()' and EPICS.
+* TypeError when diffractometer was not connected.
+
+Maintenance
+-----------
+
+* Add advice files for virtual AI chat agents.
+* Add and demonstrate SPEC-style pseudoaxes.
+* Add inverse transformation to DiffractometerBase.scan_extra() method.
+* Add virtual axes.
+* Complete 'refineLattice()' for Core and Sample.
+* Compute B from sample lattice.
+* Consistent response when no forward solutions are found.
+* Engineering units throughout
+    * Solver defines the units it uses.
+    * Conversion to/from solver's units.
+    * Lattice, beam, rotational axes can all have their own units.
+    * Ensure unit cell edge length units match wavelength units.
+* Extend 'creator()' factory for custom real axis specifications.
+* Improve code coverage.
+* New GHA jobs cancel in in-progress jobs.
+* Pick the 'forward()' solution closest to the current angles.
+* Simple math for reflections: r1+r2, r1-r2, r1 == r2, ...
+* Update table with SPEC comparison
 
 0.1.5
 #####


### PR DESCRIPTION
- closes #113

Here is a specification of custom reals for a 4-circle geometry:

```py
            dict(
                a=None,
                b="m5",
                c={"class": "ophyd.SoftPositioner", "init_pos": 10, "limits": (0, 50)},
                d={"class": "ophyd.EpicsMotor", "prefix": "m6", "labels": ["test"]},
            ),
```